### PR TITLE
feat: Make scraper_assistant extension optional

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Ignore git repository files
+.git
+.gitignore
+
+# Ignore Python cache files
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+
+# Ignore virtual environment directories
+.venv
+venv
+env
+ENV
+
+# Ignore IDE-specific files
+.idea
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Install Playwright browsers and their OS dependencies
 RUN playwright install --with-deps chromium
 
-COPY .env /app/.env
-
-COPY ./scraper_assistant /app/scraper_assistant
-
-# Copy your application code (the 'app' package) into the image
-COPY ./app ./app
-
-# Copy your frontend static files into the image
-# This creates a 'static_frontend' directory inside '/app' in the container
-COPY ./frontend ./static_frontend 
+# Copy the entire application context into the image
+# The .dockerignore file will exclude unnecessary files
+COPY . .
+# The frontend static files need to be accessible from a known path.
+# We will rename the 'frontend' directory to 'static_frontend' to match the original setup.
+RUN if [ -d frontend ]; then mv frontend static_frontend; fi
 
 # Expose the port your API will run on
 EXPOSE 8000

--- a/app/scraper.py
+++ b/app/scraper.py
@@ -128,18 +128,23 @@ async def scrape_urls(
     ]
 
     actual_extension_path = None
-    if path_to_extension_folder:
-        if not os.path.isdir(path_to_extension_folder):
-            logger.error(f"Extension path not found or not a directory: {path_to_extension_folder}. Proceeding without extension.")
+    if path_to_extension_folder and os.path.isdir(path_to_extension_folder):
+        # Also check if it's a valid extension by looking for the manifest
+        manifest_path = os.path.join(path_to_extension_folder, 'manifest.json')
+        if not os.path.isfile(manifest_path):
+            logger.warning(f"Extension directory found at '{path_to_extension_folder}', but it's missing a 'manifest.json'. Proceeding without extension.")
         else:
             actual_extension_path = os.path.abspath(path_to_extension_folder)
             browser_launch_args.extend([
                 f"--disable-extensions-except={actual_extension_path}",
                 f"--load-extension={actual_extension_path}",
             ])
-            logger.info(f"Attempting to load extension from: {actual_extension_path}")
+            logger.info(f"Confirmed valid extension, attempting to load from: {actual_extension_path}")
     else:
-        logger.info("No extension path provided. Running browser without custom extensions.")
+        if path_to_extension_folder:
+             logger.warning(f"Extension path '{path_to_extension_folder}' not found or not a directory. Proceeding without extension.")
+        else:
+            logger.info("No extension path provided. Running browser without custom extensions.")
 
     user_data_dir = tempfile.mkdtemp() 
     logger.info(f"Using temporary user data directory for Playwright: {user_data_dir}")


### PR DESCRIPTION
This change modifies the Docker build process and application code to allow the `scraper_assistant` browser extension to be optional.

- A `.dockerignore` file has been added to exclude unnecessary files from the build context.
- The `Dockerfile` is updated to use a single `COPY . .` command, which allows it to build successfully whether the `scraper_assistant` directory is present or not.
- The code in `app/scraper.py` has been made more robust. It now checks for the existence of the extension directory and a `manifest.json` file within it before attempting to load the extension, ensuring the application runs gracefully without it.