### PR TITLE
Fix article interface and RSS parsing

### DIFF
--- a/app/routers/article_routes.py
+++ b/app/routers/article_routes.py
@@ -126,8 +126,6 @@ async def get_news_summaries_endpoint(
         can_process_ai = current_text_content and not current_text_content.startswith(SCRAPING_ERROR_PREFIX) and len(current_text_content) >= TEXT_LENGTH_THRESHOLD
         article_result_data["is_summarizable"] = can_process_ai
 
-        if not article_db_obj.tags and (not current_text_content or not current_text_content.startswith(SCRAPING_ERROR_PREFIX)):
-             error_parts_for_display.append("Tags need generation.")
         if error_parts_for_display:
             article_result_data["error_message"] = " | ".join(list(set(error_parts_for_display)))
         results_on_page.append(ArticleResult(**article_result_data))
@@ -168,8 +166,6 @@ async def get_news_summaries_endpoint(
                     if not res_art.summary:
                          latest_s = db.query(database.Summary).filter(database.Summary.article_id == res_art.id).order_by(database.Summary.created_at.desc()).first()
                          if not latest_s or latest_s.summary_text.startswith("Error:"): current_error_parts_after_od_scrape.append("Summary needs generation.")
-                    if not art_db_obj_to_process.tags:
-                         current_error_parts_after_od_scrape.append("Tags need generation.")
                     res_art.error_message = " | ".join(list(set(current_error_parts_after_od_scrape))) if current_error_parts_after_od_scrape else None
                     break
     return PaginatedSummariesAPIResponse( search_source=search_source_display, requested_page=current_page_for_slice, page_size=query.page_size, total_articles_available=total_articles_available, total_pages=total_pages, processed_articles_on_page=results_on_page)

--- a/app/rss_client.py
+++ b/app/rss_client.py
@@ -184,11 +184,11 @@ async def fetch_and_store_articles_from_feed(db: Session, feed_source: RSSFeedSo
         # Fallback to the 'content' field if summary/description are missing.
         # feedparser can return 'content' as a list of content objects.
         if not raw_description and 'content' in feed_entry_data:
-            if isinstance(feed_entry_data['content'], list) and len(feed_entry_data['content']) > 0:
-                # The content object typically has a 'value' attribute.
+            if isinstance(feed_entry_data['content'], list) and feed_entry_data['content']:
+                # feedparser content is a list of dicts, each with a 'value' key.
                 content_block = feed_entry_data['content'][0]
-                if hasattr(content_block, 'value'):
-                    raw_description = content_block.value
+                if isinstance(content_block, dict) and 'value' in content_block:
+                    raw_description = content_block['value']
 
         plain_text_description = None
         if raw_description:

--- a/frontend/js/uiManager.js
+++ b/frontend/js/uiManager.js
@@ -139,6 +139,11 @@ export function displayArticleResults(articles, clearPrevious, onTagClickCallbac
     }
 
     articles.forEach((article) => {
+        // If the article is not summarizable (i.e., has no meaningful content), skip creating its card.
+        if (!article.is_summarizable) {
+            console.log(`UIManager: Skipping article ID ${article.id} ('${article.title}') because it is not summarizable.`);
+            return; // Skip this iteration
+        }
         const articleCard = document.createElement('div');
         articleCard.classList.add('article-card');
         articleCard.setAttribute('id', `article-db-${article.id}`);


### PR DESCRIPTION
This commit addresses three issues with the article interface:

1.  Hides article cards with non-meaningful text length by checking the `is_summarizable` flag on the frontend.
2.  Removes the "Tags need generation" message from the article card display by removing the backend logic that added it.
3.  Improves the RSS parser to correctly extract descriptions by checking for `summary`, `description`, and `content` fields in the RSS feed, and by stripping HTML from the content. This fixes the "no summary or description available" issue.