### PR TITLE
Refactor: Separate settings into a dedicated database

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,7 +8,9 @@ load_dotenv() # Load environment variables from .env file
 # --- Database Configuration ---
 SQLITE_DB_SUBDIR = "data"
 SQLITE_DB_FILE = "newsai.db"
+SETTINGS_DB_FILE = "settings.db"
 DATABASE_URL = os.getenv("DATABASE_URL", f"sqlite:///./{SQLITE_DB_SUBDIR}/{SQLITE_DB_FILE}")
+SETTINGS_DATABASE_URL = os.getenv("SETTINGS_DATABASE_URL", f"sqlite:///./{SQLITE_DB_SUBDIR}/{SETTINGS_DB_FILE}")
 
 # --- LLM Configuration ---
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")

--- a/app/database.py
+++ b/app/database.py
@@ -172,36 +172,6 @@ class Tag(Base):
     def __repr__(self):
         return f"<Tag(id={self.id}, name='{self.name}')>"
 
-class Configuration(Base):
-    __tablename__ = "configuration"
-    key = Column(String, primary_key=True, index=True, nullable=False)
-    value = Column(String, nullable=False)
-    def __repr__(self):
-        return f"<Configuration(key='{self.key}', value='{self.value}')>"
-
-# --- Helper functions for Configuration ---
-def get_setting(db: SQLAlchemySession, key: str, default: Optional[str] = None) -> Optional[str]:
-    """
-    Retrieves a setting value from the database.
-    Returns the default value if the key is not found.
-    """
-    setting = db.query(Configuration).filter(Configuration.key == key).first()
-    return setting.value if setting else default
-
-def set_setting(db: SQLAlchemySession, key: str, value: str):
-    """
-    Creates or updates a setting in the database.
-    """
-    setting = db.query(Configuration).filter(Configuration.key == key).first()
-    if setting:
-        setting.value = value
-    else:
-        setting = Configuration(key=key, value=value)
-        db.add(setting)
-    # Note: commit is not called here, it should be handled by the caller
-    # via db_session_scope or other session management.
-
-
 def create_db_and_tables():
     print("DATABASE: Attempting to create database tables...")
     try:

--- a/app/main_api.py
+++ b/app/main_api.py
@@ -108,7 +108,10 @@ async def startup_event():
                 temperature=0.2, max_output_tokens=app_config.SUMMARY_MAX_OUTPUT_TOKENS
             )
             app.state.llm_summary_instance = llm_summary_instance_global
-            logger.info(f"MAIN_API: Summarization LLM ({summary_model_name}) initialized.")
+            if app.state.llm_summary_instance:
+                logger.info(f"MAIN_API: Summarization LLM ({summary_model_name}) initialized.")
+            else:
+                logger.error(f"MAIN_API: Summarization LLM ({summary_model_name}) FAILED to initialize.")
 
             llm_chat_instance_global = summarizer.initialize_llm(
                 api_key=app_config.GEMINI_API_KEY,
@@ -116,7 +119,10 @@ async def startup_event():
                 temperature=0.5, max_output_tokens=app_config.CHAT_MAX_OUTPUT_TOKENS
             )
             app.state.llm_chat_instance = llm_chat_instance_global
-            logger.info(f"MAIN_API: Chat LLM ({chat_model_name}) initialized.")
+            if app.state.llm_chat_instance:
+                logger.info(f"MAIN_API: Chat LLM ({chat_model_name}) initialized.")
+            else:
+                logger.error(f"MAIN_API: Chat LLM ({chat_model_name}) FAILED to initialize.")
 
             llm_tag_instance_global = summarizer.initialize_llm(
                 api_key=app_config.GEMINI_API_KEY,
@@ -124,7 +130,10 @@ async def startup_event():
                 temperature=0.1, max_output_tokens=app_config.TAG_MAX_OUTPUT_TOKENS
             )
             app.state.llm_tag_instance = llm_tag_instance_global
-            logger.info(f"MAIN_API: Tag Generation LLM ({tag_model_name}) initialized.")
+            if app.state.llm_tag_instance:
+                logger.info(f"MAIN_API: Tag Generation LLM ({tag_model_name}) initialized.")
+            else:
+                logger.error(f"MAIN_API: Tag Generation LLM ({tag_model_name}) FAILED to initialize.")
 
         except Exception as e:
             logger.critical(f"MAIN_API: CRITICAL ERROR during LLM Initialization: {e}.", exc_info=True)

--- a/app/main_api.py
+++ b/app/main_api.py
@@ -14,7 +14,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
 # Relative imports for application modules
-from . import database 
+from . import database, settings_database # Import settings_database
 from . import config as app_config 
 from . import summarizer 
 from . import rss_client 
@@ -27,7 +27,7 @@ from .routers import (
     article_routes,
     chat_routes,
     admin_routes,
-    content_routes # Added import for the new content router
+    content_routes
 )
 
 # Configure basic logging
@@ -35,6 +35,7 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(level
 logger = logging.getLogger(__name__)
 
 # --- Global Variables ---
+# These are less critical now as app.state is the primary carrier, but can be useful for debugging.
 llm_summary_instance_global: GoogleGenerativeAI | None = None
 llm_chat_instance_global: GoogleGenerativeAI | None = None
 llm_tag_instance_global: GoogleGenerativeAI | None = None
@@ -45,7 +46,7 @@ scheduler = AsyncIOScheduler(timezone="UTC")
 # FastAPI application instance
 app = FastAPI(
     title="News Summarizer API & Frontend (Refactored)",
-    version="2.1.0", # Updated version for new feature
+    version="2.2.0", # Updated version for settings refactor
     description="API for fetching, summarizing, tagging, chatting with, and viewing full content of news articles."
 )
 
@@ -55,15 +56,22 @@ async def startup_event():
     global llm_summary_instance_global, llm_chat_instance_global, llm_tag_instance_global, scheduler
     logger.info("MAIN_API: Application startup sequence initiated...")
 
-    # 1. Initialize Database
-    logger.info("MAIN_API: Initializing database tables...")
+    # 1. Initialize Databases
+    logger.info("MAIN_API: Initializing databases...")
     try:
+        # Initialize the main article database
         database.create_db_and_tables()
-        logger.info("MAIN_API: Database tables checked/created successfully.")
+        logger.info("MAIN_API: Main article database tables checked/created successfully.")
+
+        # Initialize the new settings database
+        settings_database.create_settings_db_and_tables()
+        logger.info("MAIN_API: Settings database tables checked/created successfully.")
     except Exception as e:
         logger.critical(f"MAIN_API: CRITICAL ERROR during database initialization: {e}", exc_info=True)
+        # Depending on the error, we might want to exit here.
+        # For now, we'll log it as critical and continue.
 
-    # 2. Add Initial RSS Feeds to DB
+    # 2. Add Initial RSS Feeds to DB (from env vars, if any)
     if app_config.RSS_FEED_URLS:
         logger.info(f"MAIN_API: Ensuring initial RSS feeds are in DB from config: {app_config.RSS_FEED_URLS}")
         try:
@@ -75,24 +83,18 @@ async def startup_event():
     else:
         logger.info("MAIN_API: No initial RSS_FEED_URLS configured in app_config to add to DB.")
 
-    # 3. Initialize LLM Instances and store in app.state
-    logger.info("MAIN_API: Attempting to initialize LLM instances...")
+    # 3. Initialize LLM Instances using settings from the settings DB
+    logger.info("MAIN_API: Attempting to initialize LLM instances from settings DB...")
     if not app_config.GEMINI_API_KEY:
         logger.critical("MAIN_API: CRITICAL ERROR - GEMINI_API_KEY not found. LLM features will be disabled.")
     else:
         try:
-            with database.db_session_scope() as db:
-                summary_model_name = database.get_setting(db, "summary_model_name", app_config.DEFAULT_SUMMARY_MODEL_NAME)
-                chat_model_name = database.get_setting(db, "chat_model_name", app_config.DEFAULT_CHAT_MODEL_NAME)
-                tag_model_name = database.get_setting(db, "tag_model_name", app_config.DEFAULT_TAG_MODEL_NAME)
-
-                # Save default if not present
-                if not database.get_setting(db, "summary_model_name"):
-                    database.set_setting(db, "summary_model_name", summary_model_name)
-                if not database.get_setting(db, "chat_model_name"):
-                    database.set_setting(db, "chat_model_name", chat_model_name)
-                if not database.get_setting(db, "tag_model_name"):
-                    database.set_setting(db, "tag_model_name", tag_model_name)
+            # Use the new settings database to get model names
+            with settings_database.db_session_scope() as settings_db:
+                all_settings = settings_database.get_all_settings(settings_db)
+                summary_model_name = all_settings.get("summary_model_name")
+                chat_model_name = all_settings.get("chat_model_name")
+                tag_model_name = all_settings.get("tag_model_name")
 
             app.state.available_models = [
                 "gemini-1.5-flash-latest",
@@ -105,47 +107,45 @@ async def startup_event():
                 model_name=summary_model_name,
                 temperature=0.2, max_output_tokens=app_config.SUMMARY_MAX_OUTPUT_TOKENS
             )
-            if llm_summary_instance_global:
-                app.state.llm_summary_instance = llm_summary_instance_global
-                logger.info(f"MAIN_API: Summarization LLM ({summary_model_name}) initialized and added to app.state.")
-            else: logger.error("MAIN_API: Summarization LLM failed to initialize.")
+            app.state.llm_summary_instance = llm_summary_instance_global
+            logger.info(f"MAIN_API: Summarization LLM ({summary_model_name}) initialized.")
 
             llm_chat_instance_global = summarizer.initialize_llm(
                 api_key=app_config.GEMINI_API_KEY,
                 model_name=chat_model_name,
                 temperature=0.5, max_output_tokens=app_config.CHAT_MAX_OUTPUT_TOKENS
             )
-            if llm_chat_instance_global:
-                app.state.llm_chat_instance = llm_chat_instance_global
-                logger.info(f"MAIN_API: Chat LLM ({chat_model_name}) initialized and added to app.state.")
-            else: logger.error("MAIN_API: Chat LLM failed to initialize.")
+            app.state.llm_chat_instance = llm_chat_instance_global
+            logger.info(f"MAIN_API: Chat LLM ({chat_model_name}) initialized.")
 
             llm_tag_instance_global = summarizer.initialize_llm(
                 api_key=app_config.GEMINI_API_KEY,
                 model_name=tag_model_name,
                 temperature=0.1, max_output_tokens=app_config.TAG_MAX_OUTPUT_TOKENS
             )
-            if llm_tag_instance_global:
-                app.state.llm_tag_instance = llm_tag_instance_global
-                logger.info(f"MAIN_API: Tag Generation LLM ({tag_model_name}) initialized and added to app.state.")
-            else: logger.error("MAIN_API: Tag Generation LLM failed to initialize.")
+            app.state.llm_tag_instance = llm_tag_instance_global
+            logger.info(f"MAIN_API: Tag Generation LLM ({tag_model_name}) initialized.")
 
         except Exception as e:
             logger.critical(f"MAIN_API: CRITICAL ERROR during LLM Initialization: {e}.", exc_info=True)
-            llm_summary_instance_global = None
-            llm_chat_instance_global = None
-            llm_tag_instance_global = None
             app.state.llm_summary_instance = None
             app.state.llm_chat_instance = None
             app.state.llm_tag_instance = None
 
-
     # 4. Start APScheduler for RSS Feed Updates
     if not scheduler.running:
-        logger.info(f"MAIN_API: Configuring APScheduler to run RSS feed updates every {app_config.DEFAULT_RSS_FETCH_INTERVAL_MINUTES} minutes.")
+        # Get interval from settings DB, fallback to config
+        with settings_database.db_session_scope() as settings_db:
+             interval_minutes = int(settings_database.get_setting(
+                 settings_db,
+                 "rss_fetch_interval_minutes",
+                 str(app_config.DEFAULT_RSS_FETCH_INTERVAL_MINUTES)
+             ))
+
+        logger.info(f"MAIN_API: Configuring APScheduler to run RSS feed updates every {interval_minutes} minutes.")
         scheduler.add_job(
             tasks.trigger_rss_update_all_feeds,
-            trigger=IntervalTrigger(minutes=app_config.DEFAULT_RSS_FETCH_INTERVAL_MINUTES),
+            trigger=IntervalTrigger(minutes=interval_minutes),
             id="update_all_feeds_job",
             name="Periodic RSS Feed Update",
             replace_existing=True,
@@ -162,6 +162,7 @@ async def startup_event():
         logger.info("MAIN_API: APScheduler is already running.")
 
     logger.info("MAIN_API: Application startup sequence complete.")
+
 
 @app.on_event("shutdown")
 def shutdown_event():
@@ -183,7 +184,7 @@ app.include_router(feed_routes.router)
 app.include_router(article_routes.router)
 app.include_router(chat_routes.router)
 app.include_router(admin_routes.router)
-app.include_router(content_routes.router) # Added the new content_routes router
+app.include_router(content_routes.router)
 logger.info("MAIN_API: All API routers included.")
 
 # --- Static Files & Root Endpoint ---

--- a/app/main_api.py
+++ b/app/main_api.py
@@ -136,11 +136,15 @@ async def startup_event():
     if not scheduler.running:
         # Get interval from settings DB, fallback to config
         with settings_database.db_session_scope() as settings_db:
-             interval_minutes = int(settings_database.get_setting(
-                 settings_db,
-                 "rss_fetch_interval_minutes",
-                 str(app_config.DEFAULT_RSS_FETCH_INTERVAL_MINUTES)
-             ))
+            try:
+                interval_minutes = int(settings_database.get_setting(
+                    settings_db,
+                    "rss_fetch_interval_minutes",
+                    str(app_config.DEFAULT_RSS_FETCH_INTERVAL_MINUTES)
+                ))
+            except (ValueError, TypeError):
+                interval_minutes = app_config.DEFAULT_RSS_FETCH_INTERVAL_MINUTES
+                logger.warning(f"Invalid 'rss_fetch_interval_minutes' in settings DB, falling back to default: {interval_minutes}")
 
         logger.info(f"MAIN_API: Configuring APScheduler to run RSS feed updates every {interval_minutes} minutes.")
         scheduler.add_job(

--- a/app/routers/config_routes.py
+++ b/app/routers/config_routes.py
@@ -45,14 +45,25 @@ async def get_initial_config_endpoint(
     # 2. Fetch all settings from the settings database
     all_settings = settings_database.get_all_settings(settings_db)
 
-    # 3. Construct the AppSettings Pydantic model
-    # The get_all_settings function ensures that defaults are present.
+    # 3. Construct the AppSettings Pydantic model with robust type casting
+    try:
+        articles_per_page = int(all_settings.get("articles_per_page"))
+    except (ValueError, TypeError):
+        articles_per_page = app_config.DEFAULT_PAGE_SIZE
+        logger.warning(f"Invalid 'articles_per_page' value in settings DB. Falling back to default: {articles_per_page}")
+
+    try:
+        rss_fetch_interval_minutes = int(all_settings.get("rss_fetch_interval_minutes"))
+    except (ValueError, TypeError):
+        rss_fetch_interval_minutes = app_config.DEFAULT_RSS_FETCH_INTERVAL_MINUTES
+        logger.warning(f"Invalid 'rss_fetch_interval_minutes' value in settings DB. Falling back to default: {rss_fetch_interval_minutes}")
+
     app_settings = AppSettings(
         summary_model_name=all_settings.get("summary_model_name"),
         chat_model_name=all_settings.get("chat_model_name"),
         tag_model_name=all_settings.get("tag_model_name"),
-        articles_per_page=int(all_settings.get("articles_per_page")),
-        rss_fetch_interval_minutes=int(all_settings.get("rss_fetch_interval_minutes")),
+        articles_per_page=articles_per_page,
+        rss_fetch_interval_minutes=rss_fetch_interval_minutes,
         summary_prompt=all_settings.get("summary_prompt"),
         chat_prompt=all_settings.get("chat_prompt"),
         tag_generation_prompt=all_settings.get("tag_generation_prompt"),

--- a/app/routers/config_routes.py
+++ b/app/routers/config_routes.py
@@ -2,109 +2,133 @@
 import logging
 from fastapi import APIRouter, Depends, Request, HTTPException
 from sqlalchemy.orm import Session as SQLAlchemySession
-from typing import List, Dict, Any # For type hinting
+from typing import List, Dict, Any
 
-# Relative imports for modules within the 'app' directory
-from .. import database # To access get_db and ORM models like RSSFeedSource
-from .. import config as app_config # To access application-level configurations
+# Updated imports to use the new settings_database
+from .. import database, settings_database
+from .. import config as app_config
 from .. import summarizer
-from ..schemas import InitialConfigResponse, UpdateConfigRequest, UpdateConfigResponse # To use the Pydantic model for the response
+from ..schemas import (
+    InitialConfigResponse,
+    UpdateAppSettingsRequest,
+    UpdateAppSettingsResponse,
+    AppSettings
+)
 
-# Initialize logger for this module
 logger = logging.getLogger(__name__)
 
-# Create an APIRouter instance for these configuration-related routes
-# - prefix: a common path prefix for all routes defined in this router
-# - tags: used for grouping routes in the OpenAPI documentation (Swagger UI)
 router = APIRouter(
     prefix="/api",
     tags=["configuration"]
 )
 
 @router.get("/initial-config", response_model=InitialConfigResponse)
-async def get_initial_config_endpoint(request: Request, db: SQLAlchemySession = Depends(database.get_db)):
+async def get_initial_config_endpoint(
+    request: Request,
+    main_db: SQLAlchemySession = Depends(database.get_db),
+    settings_db: SQLAlchemySession = Depends(settings_database.get_db)
+):
     """
     Endpoint to fetch the initial configuration for the frontend.
-    This includes default RSS feeds, all feed sources from the database,
-    default application settings like articles per page, prompts, and
-    details about the browser extension and headless mode.
+    This now separates settings from other app data like feed sources.
     """
     logger.info("API Call: Fetching initial configuration.")
 
-    # Query the database for all RSSFeedSource records, ordered by name
-    db_feeds = db.query(database.RSSFeedSource).order_by(database.RSSFeedSource.name).all()
-
-    # Format the database feed sources into the structure expected by the frontend/Pydantic model
+    # 1. Fetch all feed sources from the main database
+    db_feeds = main_db.query(database.RSSFeedSource).order_by(database.RSSFeedSource.name).all()
     db_feed_sources_response: List[Dict[str, Any]] = [
         {"id": feed.id, "url": feed.url, "name": feed.name, "fetch_interval_minutes": feed.fetch_interval_minutes}
         for feed in db_feeds
     ]
-    logger.debug(f"Found {len(db_feed_sources_response)} feed sources in the database.")
+    logger.debug(f"Found {len(db_feed_sources_response)} feed sources in the main database.")
 
-    summary_model_name = database.get_setting(db, "summary_model_name", app_config.DEFAULT_SUMMARY_MODEL_NAME)
-    chat_model_name = database.get_setting(db, "chat_model_name", app_config.DEFAULT_CHAT_MODEL_NAME)
-    tag_model_name = database.get_setting(db, "tag_model_name", app_config.DEFAULT_TAG_MODEL_NAME)
+    # 2. Fetch all settings from the settings database
+    all_settings = settings_database.get_all_settings(settings_db)
 
-    # Construct and return the InitialConfigResponse object
-    # This uses values from the application's configuration (app_config)
-    # and the data retrieved from the database.
+    # 3. Construct the AppSettings Pydantic model
+    # The get_all_settings function ensures that defaults are present.
+    app_settings = AppSettings(
+        summary_model_name=all_settings.get("summary_model_name"),
+        chat_model_name=all_settings.get("chat_model_name"),
+        tag_model_name=all_settings.get("tag_model_name"),
+        articles_per_page=int(all_settings.get("articles_per_page")),
+        rss_fetch_interval_minutes=int(all_settings.get("rss_fetch_interval_minutes")),
+        summary_prompt=all_settings.get("summary_prompt"),
+        chat_prompt=all_settings.get("chat_prompt"),
+        tag_generation_prompt=all_settings.get("tag_generation_prompt"),
+    )
+
+    # 4. Construct and return the main response object
     response_data = InitialConfigResponse(
-        default_rss_feeds=app_config.RSS_FEED_URLS,
+        settings=app_settings,
+        default_rss_feeds=app_config.RSS_FEED_URLS, # This remains from env/config
         all_db_feed_sources=db_feed_sources_response,
-        default_articles_per_page=app_config.DEFAULT_PAGE_SIZE,
-        default_summary_prompt=app_config.DEFAULT_SUMMARY_PROMPT,
-        default_chat_prompt=app_config.DEFAULT_CHAT_PROMPT,
-        default_tag_generation_prompt=app_config.DEFAULT_TAG_GENERATION_PROMPT,
-        default_rss_fetch_interval_minutes=app_config.DEFAULT_RSS_FETCH_INTERVAL_MINUTES,
         path_to_extension=app_config.PATH_TO_EXTENSION,
         use_headless_browser=app_config.USE_HEADLESS_BROWSER,
-        summary_model_name=summary_model_name,
-        chat_model_name=chat_model_name,
-        tag_model_name=tag_model_name,
         available_models=request.app.state.available_models
     )
     logger.info("Successfully prepared initial configuration response.")
     return response_data
 
-@router.put("/config", response_model=UpdateConfigResponse)
-async def update_config_endpoint(request: Request, config_update: UpdateConfigRequest, db: SQLAlchemySession = Depends(database.get_db)):
-    with database.db_session_scope() as db_session:
-        database.set_setting(db_session, "summary_model_name", config_update.summary_model_name)
-        database.set_setting(db_session, "chat_model_name", config_update.chat_model_name)
-        database.set_setting(db_session, "tag_model_name", config_update.tag_model_name)
+@router.put("/config", response_model=UpdateAppSettingsResponse)
+async def update_app_settings_endpoint(
+    request: Request,
+    config_update: UpdateAppSettingsRequest,
+    settings_db: SQLAlchemySession = Depends(settings_database.get_db)
+):
+    """
+    Endpoint to update all application settings.
+    Receives a single object with all settings and saves them to the settings database.
+    """
+    logger.info("API Call: Updating application settings.")
 
-    # Re-initialize LLMs
     try:
+        # 1. Save all settings to the settings database
+        with settings_database.db_session_scope() as db_session:
+            settings_dict = config_update.settings.model_dump()
+            settings_database.set_multiple_settings(db_session, settings_dict)
+
+        logger.info("Successfully saved settings to the database.")
+
+        # 2. Re-initialize LLMs with the new model names
         app = request.app
+        updated_settings = config_update.settings
+
+        # Initialize Summary LLM
         summary_llm = summarizer.initialize_llm(
             api_key=app_config.GEMINI_API_KEY,
-            model_name=config_update.summary_model_name,
+            model_name=updated_settings.summary_model_name,
             temperature=0.2, max_output_tokens=app_config.SUMMARY_MAX_OUTPUT_TOKENS
         )
         if summary_llm:
             app.state.llm_summary_instance = summary_llm
 
+        # Initialize Chat LLM
         chat_llm = summarizer.initialize_llm(
             api_key=app_config.GEMINI_API_KEY,
-            model_name=config_update.chat_model_name,
+            model_name=updated_settings.chat_model_name,
             temperature=0.5, max_output_tokens=app_config.CHAT_MAX_OUTPUT_TOKENS
         )
         if chat_llm:
             app.state.llm_chat_instance = chat_llm
 
+        # Initialize Tag LLM
         tag_llm = summarizer.initialize_llm(
             api_key=app_config.GEMINI_API_KEY,
-            model_name=config_update.tag_model_name,
+            model_name=updated_settings.tag_model_name,
             temperature=0.1, max_output_tokens=app_config.TAG_MAX_OUTPUT_TOKENS
         )
         if tag_llm:
             app.state.llm_tag_instance = tag_llm
 
-        return UpdateConfigResponse(
-            summary_model_name=config_update.summary_model_name,
-            chat_model_name=config_update.chat_model_name,
-            tag_model_name=config_update.tag_model_name
+        logger.info("Successfully re-initialized AI models.")
+
+        # 3. Return a success response with the updated settings
+        return UpdateAppSettingsResponse(
+            message="Settings updated successfully.",
+            settings=updated_settings
         )
+
     except Exception as e:
-        logger.error(f"Error re-initializing LLMs after config update: {e}")
-        raise HTTPException(status_code=500, detail="Failed to re-initialize AI models.")
+        logger.error(f"Error updating application settings: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to update settings: {e}")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -3,32 +3,33 @@ from pydantic import BaseModel, HttpUrl, Field
 from typing import List, Optional, Dict, Any
 from datetime import datetime
 
-# --- Pydantic Models ---
-class InitialConfigResponse(BaseModel):
-    default_rss_feeds: List[str]
-    all_db_feed_sources: List[Dict[str, Any]]
-    default_articles_per_page: int
-    default_summary_prompt: str
-    default_chat_prompt: str
-    default_tag_generation_prompt: str
-    default_rss_fetch_interval_minutes: int
-    path_to_extension: str
-    use_headless_browser: bool
+# --- Pydantic Models for Settings ---
+class AppSettings(BaseModel):
     summary_model_name: str
     chat_model_name: str
     tag_model_name: str
+    articles_per_page: int
+    rss_fetch_interval_minutes: int
+    summary_prompt: str
+    chat_prompt: str
+    tag_generation_prompt: str
+
+class InitialConfigResponse(BaseModel):
+    settings: AppSettings
+    # Non-settings values
+    default_rss_feeds: List[str]
+    all_db_feed_sources: List[Dict[str, Any]]
+    path_to_extension: str
+    use_headless_browser: bool
     available_models: List[str]
     class Config: from_attributes = True
 
-class UpdateConfigRequest(BaseModel):
-    summary_model_name: str
-    chat_model_name: str
-    tag_model_name: str
+class UpdateAppSettingsRequest(BaseModel):
+    settings: AppSettings
 
-class UpdateConfigResponse(BaseModel):
-    summary_model_name: str
-    chat_model_name: str
-    tag_model_name: str
+class UpdateAppSettingsResponse(BaseModel):
+    message: str
+    settings: AppSettings
 
 class FeedSourceResponse(BaseModel):
     id: int

--- a/app/settings_database.py
+++ b/app/settings_database.py
@@ -1,0 +1,131 @@
+# app/settings_database.py
+import os
+from sqlalchemy import create_engine, Column, String
+from sqlalchemy.orm import sessionmaker, Session as SQLAlchemySession, declarative_base
+from sqlalchemy.sql import func
+from contextlib import contextmanager
+from typing import Generator, Optional, Dict, Any
+
+from . import config
+
+# --- Database Configuration for Settings ---
+SETTINGS_DATABASE_URL = config.SETTINGS_DATABASE_URL
+
+# Ensure the directory for the SQLite database exists
+if SETTINGS_DATABASE_URL.startswith("sqlite:///./"):
+    db_file_path = SETTINGS_DATABASE_URL.replace("sqlite:///./", "")
+    db_dir = os.path.dirname(db_file_path)
+    if db_dir and not os.path.exists(db_dir):
+        os.makedirs(db_dir, exist_ok=True)
+
+engine = create_engine(
+    SETTINGS_DATABASE_URL,
+    connect_args={"check_same_thread": False} if SETTINGS_DATABASE_URL.startswith("sqlite") else {}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+# --- Context Manager for DB Sessions ---
+@contextmanager
+def db_session_scope() -> Generator[SQLAlchemySession, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    finally:
+        db.close()
+
+def get_db() -> Generator[SQLAlchemySession, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+# --- Settings Database Model ---
+class Configuration(Base):
+    __tablename__ = "configuration"
+    key = Column(String, primary_key=True, index=True, nullable=False)
+    value = Column(String, nullable=False)
+
+    def __repr__(self):
+        return f"<Configuration(key='{self.key}', value='{self.value}')>"
+
+# --- Default Settings ---
+DEFAULT_SETTINGS: Dict[str, str] = {
+    "summary_model_name": config.DEFAULT_SUMMARY_MODEL_NAME,
+    "chat_model_name": config.DEFAULT_CHAT_MODEL_NAME,
+    "tag_model_name": config.DEFAULT_TAG_MODEL_NAME,
+    "articles_per_page": str(config.DEFAULT_PAGE_SIZE),
+    "rss_fetch_interval_minutes": str(config.DEFAULT_RSS_FETCH_INTERVAL_MINUTES),
+    "summary_prompt": config.DEFAULT_SUMMARY_PROMPT,
+    "chat_prompt": config.DEFAULT_CHAT_PROMPT,
+    "tag_generation_prompt": config.DEFAULT_TAG_GENERATION_PROMPT,
+}
+
+# --- Helper functions for Configuration ---
+def get_setting(db: SQLAlchemySession, key: str, default: Optional[str] = None) -> Optional[str]:
+    """
+    Retrieves a setting value from the database.
+    Returns the default value if the key is not found.
+    """
+    setting = db.query(Configuration).filter(Configuration.key == key).first()
+    return setting.value if setting else default
+
+def set_setting(db: SQLAlchemySession, key: str, value: str):
+    """
+    Creates or updates a setting in the database.
+    """
+    setting = db.query(Configuration).filter(Configuration.key == key).first()
+    if setting:
+        setting.value = value
+    else:
+        setting = Configuration(key=key, value=value)
+        db.add(setting)
+
+def get_all_settings(db: SQLAlchemySession) -> Dict[str, str]:
+    """
+    Retrieves all settings from the database.
+    """
+    settings = db.query(Configuration).all()
+    # Ensure default settings are considered if not in DB
+    result = {k: v for k, v in DEFAULT_SETTINGS.items()}
+    for setting in settings:
+        result[setting.key] = setting.value
+    return result
+
+def set_multiple_settings(db: SQLAlchemySession, settings_to_update: Dict[str, Any]):
+    """
+    Updates multiple settings in the database from a dictionary.
+    """
+    for key, value in settings_to_update.items():
+        # Ensure value is a string before setting
+        str_value = str(value)
+        set_setting(db, key, str_value)
+
+# --- Database Initialization ---
+def create_settings_db_and_tables():
+    """
+    Creates the database and the configuration table.
+    Populates the table with default settings if they don't exist.
+    """
+    print("SETTINGS_DB: Attempting to create settings database tables...")
+    try:
+        Base.metadata.create_all(bind=engine)
+        print("SETTINGS_DB: Settings database tables checked/created successfully.")
+
+        with db_session_scope() as db:
+            for key, value in DEFAULT_SETTINGS.items():
+                existing_setting = db.query(Configuration).filter(Configuration.key == key).first()
+                if not existing_setting:
+                    print(f"SETTINGS_DB: Initializing default setting for '{key}'.")
+                    new_setting = Configuration(key=key, value=str(value))
+                    db.add(new_setting)
+            print("SETTINGS_DB: Default settings checked and initialized.")
+    except Exception as e:
+        print(f"SETTINGS_DB: Error during settings database setup: {e}")

--- a/app/settings_database.py
+++ b/app/settings_database.py
@@ -114,16 +114,15 @@ def create_settings_db_and_tables():
     Creates the database and the configuration table.
     Populates the table with default settings if they don't exist.
     """
-    logger.info("SETTINGS_DB: Attempting to create settings database tables...")
+    print("SETTINGS_DB: Attempting to create settings database tables...")
     try:
         Base.metadata.create_all(bind=engine)
         print("SETTINGS_DB: Settings database tables checked/created successfully.")
 
         with db_session_scope() as db:
-            # Fetch keys that are already in the DB to avoid adding them again
-            existing_keys = {s.key for s in db.query(Configuration.key).all()}
             for key, value in DEFAULT_SETTINGS.items():
-                if key not in existing_keys:
+                existing_setting = db.query(Configuration).filter(Configuration.key == key).first()
+                if not existing_setting:
                     print(f"SETTINGS_DB: Initializing default setting for '{key}'.")
                     new_setting = Configuration(key=key, value=str(value))
                     db.add(new_setting)

--- a/app/settings_database.py
+++ b/app/settings_database.py
@@ -120,9 +120,10 @@ def create_settings_db_and_tables():
         print("SETTINGS_DB: Settings database tables checked/created successfully.")
 
         with db_session_scope() as db:
+            # Fetch keys that are already in the DB to avoid adding them again
+            existing_keys = {s.key for s in db.query(Configuration.key).all()}
             for key, value in DEFAULT_SETTINGS.items():
-                existing_setting = db.query(Configuration).filter(Configuration.key == key).first()
-                if not existing_setting:
+                if key not in existing_keys:
                     print(f"SETTINGS_DB: Initializing default setting for '{key}'.")
                     new_setting = Configuration(key=key, value=str(value))
                     db.add(new_setting)

--- a/app/settings_database.py
+++ b/app/settings_database.py
@@ -114,7 +114,7 @@ def create_settings_db_and_tables():
     Creates the database and the configuration table.
     Populates the table with default settings if they don't exist.
     """
-    print("SETTINGS_DB: Attempting to create settings database tables...")
+    logger.info("SETTINGS_DB: Attempting to create settings database tables...")
     try:
         Base.metadata.create_all(bind=engine)
         print("SETTINGS_DB: Settings database tables checked/created successfully.")


### PR DESCRIPTION
This commit refactors the application to store all user-configurable settings in a separate SQLite database (`settings.db`). This ensures that settings are persisted independently from the main application data (articles, feeds, etc.) and are not wiped out when the article database is cleared.

Key changes:
- A new `settings_database.py` module is introduced to encapsulate all logic for the settings database, including initialization with default values.
- The `Configuration` model and related helpers have been moved from the main `database.py` to the new `settings_database.py`.
- The application startup logic in `main_api.py` is updated to initialize both databases and load settings from the new source.
- API endpoints and Pydantic schemas (`config_routes.py`, `schemas.py`) are updated to handle the new centralized settings structure.
- The frontend (`configManager.js`) is completely overhauled to remove all reliance on `localStorage` for settings. It now fetches all settings from the backend on load and saves them back in a single transaction, making the backend the single source of truth.