### PR TITLE
fix(articles): Handle null is_favorite values gracefully

### DIFF
--- a/app/routers/article_routes.py
+++ b/app/routers/article_routes.py
@@ -91,7 +91,7 @@ def _create_article_result(
         created_at=article_db_obj.created_at,
         source_feed_url=article_db_obj.feed_source.url if article_db_obj.feed_source else None,
         tags=[ArticleTagResponse.from_orm(tag) for tag in article_db_obj.tags],
-        is_favorite=article_db_obj.is_favorite,
+        is_favorite=article_db_obj.is_favorite or False,
         is_summarizable=is_summarizable,
         error_message=error_message
     )


### PR DESCRIPTION
When creating an ArticleResult, the is_favorite field was being assigned a value directly from the database. For older articles that existed before the is_favorite column was added, this value could be NULL, causing a Pydantic validation error because the field expects a boolean.

This change modifies the assignment to use `or False`, which safely converts any `None` values to `False`, preventing the validation error and ensuring API stability.