### PR TITLE
I've made the following changes:

### DIFF
--- a/frontend/js/configManager.js
+++ b/frontend/js/configManager.js
@@ -174,7 +174,7 @@ async function saveConfiguration() {
 /**
  * Saves the content preference settings (articles per page, min word count).
  */
-export function saveContentPreferences(articlesPerPage, minWordCount, callback) {
+export async function saveContentPreferences(articlesPerPage, minWordCount, callback) {
     const newArticlesPerPage = parseInt(articlesPerPage);
     const newMinWordCount = parseInt(minWordCount);
 
@@ -190,7 +190,7 @@ export function saveContentPreferences(articlesPerPage, minWordCount, callback) 
     state.setArticlesPerPage(newArticlesPerPage);
     state.setMinimumWordCount(newMinWordCount);
     updateSetupUI();
-    saveConfiguration(); // Persist all settings
+    await saveConfiguration(); // Persist all settings
     state.setCurrentPage(1);
     if (callback && typeof callback === 'function') {
         callback();
@@ -266,9 +266,9 @@ export function setupFormEventListeners(callbacks = {}) {
         console.warn("ConfigManager: Forms not found, cannot attach event listeners.");
         return;
     }
-    contentPrefsForm.addEventListener('submit', (e) => {
+    contentPrefsForm.addEventListener('submit', async (e) => {
         e.preventDefault();
-        saveContentPreferences(numArticlesSetupInput.value, minimumWordCountSetupInput.value, callbacks.onArticlesPerPageChange);
+        await saveContentPreferences(numArticlesSetupInput.value, minimumWordCountSetupInput.value, callbacks.onArticlesPerPageChange);
     });
     aiPromptsForm.addEventListener('submit', (e) => {
         e.preventDefault();

--- a/frontend/js/uiManager.js
+++ b/frontend/js/uiManager.js
@@ -18,6 +18,21 @@ let resultsContainer, loadingIndicator, loadingText, infiniteScrollLoadingIndica
 
 
 /**
+ * Truncates text to a specified word limit.
+ * @param {string} text - The text to truncate.
+ * @param {number} wordLimit - The maximum number of words.
+ * @returns {string} The truncated text with an ellipsis if it was shortened.
+ */
+function truncateText(text, wordLimit) {
+    if (!text) return "";
+    const words = text.trim().split(/\s+/);
+    if (words.length <= wordLimit) {
+        return text;
+    }
+    return words.slice(0, wordLimit).join(" ") + "...";
+}
+
+/**
  * Initializes DOM references for UI elements.
  */
 export function initializeUIDOMReferences() {
@@ -248,7 +263,8 @@ export function displayArticleResults(articles, clearPrevious, onTagClickCallbac
         } else {
             const descriptionP = document.createElement('p');
             descriptionP.classList.add('content-snippet'); // Re-using class for styling
-            descriptionP.textContent = article.rss_description || "No summary or description available.";
+            const truncatedDescription = truncateText(article.rss_description, 100);
+            descriptionP.textContent = truncatedDescription || "No summary or description available.";
             summaryContainer.appendChild(descriptionP);
 
             const summarizeBtn = document.createElement('button');


### PR DESCRIPTION
I fixed a race condition in the frontend where changing your content preferences would trigger an article refresh before the new settings were persisted on the backend. I resolved this by making the configuration save function and its calling event listener asynchronous using `async/await`.

I also added a client-side truncation feature to shorten long article descriptions to about 100 words. To do this, I added a helper function to `uiManager.js` and applied it to the `rss_description` field during article card rendering.